### PR TITLE
fix(android): determine an all day event by midnight to midnight

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,58 +313,19 @@ window.plugins.calendar.createEventWithOptions(
 
 ##### Create All-Day Event
 
-On iOS, an event is treated as all-day when the date range covers full days from midnight to midnight. On Android, set `options.allday = true`; for silent event creation Android also checks that the event duration is a whole number of days. Use midnight-to-midnight dates to avoid timezone surprises.
+On iOS and Android, an event is treated as all-day when the date range runs from local midnight to local midnight on a later day. `new Date(year, month, day)` creates a date at local midnight, so no additional zero arguments or options are needed, example:
 
 ```js
-// Set the start date to midnight and the end date to midnight the next day.
-const startDate = new Date(2027, 2, 15, 0, 0, 0, 0, 0)
-const endDate = new Date(2027, 2, 16, 0, 0, 0, 0, 0)
-
-const options = window.plugins.calendar.getCalendarOptions()
-// Android only: mark this event as all-day.
-options.allday = true
-
-window.plugins.calendar.createEventWithOptions(
-  "My all-day event",
-  "Home",
-  "Some notes about this event.",
-  startDate,
-  endDate,
-  options,
-  () => {
-    console.log("All-day event created")
-  },
-  (errorMessage) => {
-    console.error(`Error creating all-day event, errorMessage=${errorMessage}`)
-  }
-)
+const startDate = new Date(2027, 2, 15)
+const endDate = new Date(2027, 2, 16)
 ```
 
 ##### Create Multi-Day All-Day Event
 
 ```js
-// Set the start date to midnight and the end date to midnight 3 days later.
-const startDate = new Date(2027, 2, 24, 0, 0, 0, 0, 0)
-const endDate = new Date(2027, 2, 27, 0, 0, 0, 0, 0)
+const startDate = new Date(2027, 2, 24)
+const endDate = new Date(2027, 2, 27)
 
-const options = window.plugins.calendar.getCalendarOptions()
-// Android only: mark this event as all-day.
-options.allday = true
-
-window.plugins.calendar.createEventWithOptions(
-  "My 3-day event",
-  "Home",
-  "Some notes about this event.",
-  startDate,
-  endDate,
-  options,
-  () => {
-    console.log("3-day event created")
-  },
-  (errorMessage) => {
-    console.error(`Error creating 3-day event, errorMessage=${errorMessage}`)
-  }
-)
 ```
 
 ##### Get Calendar Options
@@ -391,7 +352,7 @@ Start with this object and override only the properties you need. The JavaScript
 | `recurrenceByMonthDay` | `null` | Android only | RRULE `BYMONTHDAY` value, for example `15`. Supported by silent event creation only. |
 | `recurrenceEndDate` | `null` | Android, iOS | JavaScript `Date` at which the recurrence ends. Leave `null` for no end date. |
 | `recurrenceCount` | `null` | Android only | RRULE `COUNT` value, for example `5` to repeat 5 times. Supported by silent event creation only. |
-| `allday` | `null` | Android only | Set to `true` for an all-day event. For silent event creation, Android also checks that the event duration is a whole number of days. Use midnight-to-midnight dates to avoid timezone surprises. iOS ignores this option and detects all-day events from the date range. |
+| `allday` | `null` | Android only | Deprecated. Android detects all-day events from a local-midnight-to-local-midnight date range; iOS does the same. Since version 5.2.1. |
 | `calendarName` | `null` | iOS | Selects the calendar by name or identifier. If omitted, iOS uses the default calendar for new events. Android ignores this for event creation. |
 | `calendarId` | `null` | Android | Selects the Android calendar id. If omitted during event creation, Android defaults to `1`. iOS ignores this. |
 | `url` | `null` | Android, iOS | Adds a URL to the event. iOS stores it as the event URL. Android appends it to the event notes because Android calendar events do not expose the same URL field. |

--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -600,7 +600,7 @@ public abstract class AbstractCalendarAccessor {
                               Integer calendarId, String url) {
         ContentResolver cr = this.cordova.getActivity().getContentResolver();
         ContentValues values = new ContentValues();
-        final boolean allDayEvent = "true".equals(allday) && isAllDayEvent(new Date(startTime), new Date(endTime));
+        final boolean allDayEvent = isAllDayEvent(new Date(startTime), new Date(endTime));
         if (allDayEvent) {
             //all day events must be in UTC time zone per Android specification, getOffset accounts for daylight savings time
             values.put(Events.EVENT_TIMEZONE, "UTC");
@@ -773,6 +773,18 @@ public abstract class AbstractCalendarAccessor {
     }
 
     public static boolean isAllDayEvent(final Date startDate, final Date endDate) {
-        return ((endDate.getTime() - startDate.getTime()) % (24 * 60 * 60 * 1000) == 0);
+        final java.util.Calendar startCalendar = java.util.Calendar.getInstance();
+        startCalendar.setTime(startDate);
+        final java.util.Calendar endCalendar = java.util.Calendar.getInstance();
+        endCalendar.setTime(endDate);
+
+        return isMidnight(startCalendar) && isMidnight(endCalendar) && endCalendar.after(startCalendar);
+    }
+
+    private static boolean isMidnight(final java.util.Calendar calendar) {
+        return calendar.get(java.util.Calendar.HOUR_OF_DAY) == 0
+            && calendar.get(java.util.Calendar.MINUTE) == 0
+            && calendar.get(java.util.Calendar.SECOND) == 0
+            && calendar.get(java.util.Calendar.MILLISECOND) == 0;
     }
 }

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -80,7 +80,7 @@ Calendar.prototype.getCalendarOptions = function () {
     recurrenceByMonthDay: null, // Android only: RRULE BYMONTHDAY value, example: '15'
     recurrenceEndDate: null, // example: new Date(2027, 10, 1)
     recurrenceCount: null, // Android only: RRULE COUNT value, example: 5
-    allday: null, // Android only: set true for all-day events with a whole-day duration
+    allday: null, // Android only: Deprecated set true for all-day events with a whole-day duration
     calendarName: null, // iOS only
     calendarId: null, // Android only
     url: null


### PR DESCRIPTION
- On Android it was not enought to set the start and end date from local midnight to local midnight on a later day. It was also necessary to set `allday: true` in the options. This property is deprecated now and an all day event is determined by 24 hours from local midnight to local midnight on a later day.
- Update readme